### PR TITLE
wildcard field now allows events like 'busy' to match

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
         input {
             cursor: pointer;
         }
+        input[type="text"] {
+            cursor: text;
+        }
         .table {
             display: table;
             width: 100%;
@@ -74,8 +77,15 @@
                         <option value="candy_cane">Candy cane (old)</option>
                         <option value="smooth_vertical_bands">Smooth vertical bands</option>
                         <option value="vertical_bands_fade_merge">Fuzzy vertical bands</option>
-                        
-                     </select>
+                    </select>
+                </div>
+            </div>
+            <div class="row" >
+                <div class="cell left" title="An event with this word in the title will match with any other title.&#10;'busy' is a common use case for this feature.&#10;Clear the textbox if you are getting undesirable results" >
+                    Wildcard
+                </div>
+                <div class="cell right" >
+                    <input id="wildcard_value" style="width: 150px;" type="text" placeholder="wildcard" value="busy">
                 </div>
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -2,19 +2,25 @@ window.onload = function () {
 
     const getDisabled = () => new Promise(res => chrome.storage.local.get('disabled', (s) => res(s.disabled)));
     const getStyle = () => new Promise(res => chrome.storage.local.get('style', (s) => res(s.style)));
+    const getWildcard = () => new Promise(res => chrome.storage.local.get('wildcard', (s) => res(s.wildcard)));
 
     const setIcon = (disabled) => chrome.action.setIcon({
         path: disabled ? "icon-disabled.png" : "icon.png"
     });
 
-    const setDropdown = (id, value) => {    
+    const setDropdown = (id, value) => {
         let element = document.getElementById(id);
         element.value = value;
     }
 
-    const setToggle = (id, value) => {   
+    const setToggle = (id, value) => {
         let element = document.getElementById(id);
         element.checked = value
+    }
+
+    const setWildcard = (id, value) => {
+        let element = document.getElementById(id);
+        element.value = value
     }
 
     getDisabled().then(disabled => {
@@ -32,6 +38,14 @@ window.onload = function () {
         setDropdown('select_style',value)
     });
 
+    getWildcard().then(value => {
+        if (value == null) {
+            value = 'busy'
+            chrome.storage.local.set({ 'wildcard': value });
+        }
+        setWildcard('wildcard_value',value)
+    });
+
     const manifest_data = chrome.runtime.getManifest();
     document.getElementById('version').innerHTML=`V${manifest_data.version}`
 
@@ -46,4 +60,8 @@ window.onload = function () {
         chrome.storage.local.set({ 'style': e.target.value });
     };
 
+    document.getElementById('wildcard_value').onchange = function (e) {
+        if (e.target.value.length < 3 && e.target.value !== '') return alert('wildcard too short, you are going to get problems. If you do not want wildcard matching make this textbox blank')
+        chrome.storage.local.set({ 'wildcard': e.target.value });
+    };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,16 +2,16 @@
   "name": "__MSG_appName__",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
-  "version": "2.3.4",
-      "content_scripts":[{
-        "matches": [
-            "https://www.google.com/calendar/*",
-            "https://calendar.google.com/calendar/*"
-        ],
-        "js": [ "chroma.min.js", "events.user.js" ],
-        "run_at": "document_end",
-        "all_frames": true
-    }],
+  "version": "2.3.5",
+  "content_scripts":[{
+    "matches": [
+        "https://www.google.com/calendar/*",
+        "https://calendar.google.com/calendar/*"
+    ],
+    "js": [ "chroma.min.js", "events.user.js" ],
+    "run_at": "document_end",
+    "all_frames": true
+  }],
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
![image](https://github.com/imightbeamy/gcal-multical-event-merge/assets/40216444/208eb100-b7a1-4f8d-8100-520c4d2f1a27)
![image](https://github.com/imightbeamy/gcal-multical-event-merge/assets/40216444/94eba03b-f7dd-4443-85c7-443d336f2b01)

When the extension performs merging, whatever word is typed in that box can be substituted with any other string to allow a match to happen. e.g:
if wildcard is `busy` then `busy` matches with `squash court booking` if they are same time and date
`private` then `dental appointment private` matches with `dental appointment` if they are same time and date

This is likely to be a starting point for user specified regex but I'd like to see if people have at least one example use as I don't even think the private example I gave is really a thing...

H