### PR TITLE
use | between words to allow wildcard matching on multiple strings

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -227,8 +227,15 @@ function findMatchingString(eventSets, string_1, wildcard) {
     const escapeRegExp = string => string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     const escaped_string_1 = escapeRegExp(string_1)
 
-    // Replace the wildcard pattern with a regex wildcard (.*)
-    const regex_pattern = escaped_string_1.replace(user_regex_pattern, ".*")
+    // Split the wildcard by '|' to support multiple conditions (OR)
+    const split_wildcards = stripped_wildcard.split("|")
+    let regex_pattern = escaped_string_1
+
+    // Replace each wildcard in the escaped string with the wildcard regex
+    split_wildcards.forEach(pattern => {
+        const temp_pattern = new RegExp(escapeRegExp(pattern), "i")
+        regex_pattern = regex_pattern.replace(temp_pattern, ".*")
+    })
 
     const array = Object.keys(eventSets)
 

--- a/index.html
+++ b/index.html
@@ -55,24 +55,21 @@
         }
     </style>
     <body>
-        <p id="version" ></p>
-        <h1>Cal Merge for <br>Google Calendar<sup style="font-size: 50%;">TM</sup></h1>
-        <h4>By <a href="https://github.com/hcawn/gcal-multical-event-merge/" target="_blank" >HCAWN</a></h4><h5>Forked from <a href="https://github.com/imightbeamy/gcal-multical-event-merge" target="_blank" >imightbeamy</a></h5>
-        <div class="table" >
-            <div class="row" >
-                <div class="cell left" >
-                    Enable
-                </div>
-                <div class="cell right" >
-                    <input id="toggle_enabled" type="checkbox">
+        <p id="version"></p>
+        <h1>Cal Merge for <br />Google Calendar<sup style="font-size: 50%">TM</sup></h1>
+        <h4>By <a href="https://github.com/hcawn/gcal-multical-event-merge/" target="_blank">HCAWN</a></h4>
+        <h5>Forked from <a href="https://github.com/imightbeamy/gcal-multical-event-merge" target="_blank">imightbeamy</a></h5>
+        <div class="table">
+            <div class="row">
+                <div class="cell left">Enable</div>
+                <div class="cell right">
+                    <input id="toggle_enabled" type="checkbox" />
                 </div>
             </div>
-            <div class="row" >
-                <div class="cell left" >
-                    Style
-                </div>
-                <div class="cell right" >
-                    <select id="select_style" >
+            <div class="row">
+                <div class="cell left">Style</div>
+                <div class="cell right">
+                    <select id="select_style">
                         <option value="vertical_bands">Vertical bands (default)</option>
                         <option value="candy_cane">Candy cane (old)</option>
                         <option value="smooth_vertical_bands">Smooth vertical bands</option>
@@ -80,15 +77,17 @@
                     </select>
                 </div>
             </div>
-            <div class="row" >
-                <div class="cell left" title="An event with this word in the title will match with any other title.&#10;'busy' is a common use case for this feature.&#10;Clear the textbox if you are getting undesirable results" >
+            <div class="row">
+                <div
+                    class="cell left"
+                    title="An event with this word in the title will match with any other title.&#10;'busy' is a common use case for this feature.&#10;Use the pipe character | to make multiple wildcards. e.g: 'busy|another'&#10;Clear the textbox if you are getting undesirable results"
+                >
                     Wildcard
                 </div>
-                <div class="cell right" >
-                    <input id="wildcard_value" style="width: 150px;" type="text" placeholder="wildcard" value="busy">
+                <div class="cell right">
+                    <input id="wildcard_value" style="width: 150px" type="text" placeholder="wildcard" value="busy" />
                 </div>
             </div>
         </div>
-
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
     <body>
         <p id="version"></p>
         <h1>Cal Merge for <br />Google Calendar<sup style="font-size: 50%">TM</sup></h1>
-        <h4>By <a href="https://github.com/hcawn/gcal-multical-event-merge/" target="_blank">HCAWN</a></h4>
-        <h5>Forked from <a href="https://github.com/imightbeamy/gcal-multical-event-merge" target="_blank">imightbeamy</a></h5>
+        <h4>By <a href="https://github.com/hcawn/gcal-multical-event-merge/" target="_blank" style="color: black">HCAWN</a></h4>
+        <h5>Forked from <a href="https://github.com/imightbeamy/gcal-multical-event-merge" target="_blank" style="color: black">imightbeamy</a></h5>
         <div class="table">
             <div class="row">
                 <div class="cell left">Enable</div>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2.3.8",
+    "version": "2.3.9",
     "content_scripts": [
         {
             "matches": ["https://www.google.com/calendar/*", "https://calendar.google.com/calendar/*"],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06b9ff65-40d0-41d2-b0c4-f670599de7d2)
allow matching with multiple wildcards at once by seperating strings with the "pipe" character |
Beware about trailing spaces.