### PR TITLE
Fix Google's breaking change for event stacking in month view

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -321,7 +321,7 @@ const moveEvents = (events, from_top) => {
     if (!otherEventsMoved.includes(events[0])) {
         // if parent has roll = "presentation" then do not move as it is a day column
         // recent change to google cal means I now have to look to the parents parent and look for gridcell role.
-        if (["gridcell", "presentation"].includes(events[0].parentElement.parentElement.getAttribute("role"))) {
+        if (["gridcell"].includes(events[0].parentElement.parentElement.getAttribute("role"))) {
             return
         }
         events[0].parentElement.style.top = `${from_top}em`

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "default_locale": "en",
-    "version": "2.3.10",
+    "version": "2.3.11",
     "content_scripts": [
         {
             "matches": ["https://www.google.com/calendar/*", "https://calendar.google.com/calendar/*"],


### PR DESCRIPTION
Wasn't too hard to figure out in the end. One of many little things Google changed with they updated the code last month.
I think they updated it in preperation for support for dark mode which is now live.

![image](https://github.com/user-attachments/assets/bdf9d6a0-cc8d-42f5-b5b0-ada4bcaf1b8b)

This fix is in review with Chrome Store, maybe 24 hours until it's live. 

Look out for V 2.3.11