### PR TITLE
Anchor matching string to head and tail to avoid invalid partial match

### DIFF
--- a/events.user.js
+++ b/events.user.js
@@ -240,7 +240,7 @@ function findMatchingString(eventSets, string_1, wildcard) {
     const array = Object.keys(eventSets)
 
     for (const str of array) {
-        if (str.match(new RegExp(regex_pattern, "i"))) {
+        if (str.match(new RegExp(`^${regex_pattern}\$`, "i"))) {
             return str
         }
     }


### PR DESCRIPTION
If `str` has `event (my favorite)` and `eventSets[]` has `event` string, current code matches as `"event (my favorite)".match(new RegExp("event", "i"))` which is wrong.

I'm not sure `wildcard` related code, but this patch fixes this situation in my schedule environment.